### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/qavajs/steps-memory/security/code-scanning/2](https://github.com/qavajs/steps-memory/security/code-scanning/2)

To fix the problem, add a `permissions` block at the top level of the workflow, just after the `name` key. This ensures all jobs in the workflow inherit the specified minimal permissions for the GITHUB_TOKEN, promoting the principle of least privilege. As a minimal starting point (and since the job appears to only build and test code, not write to the repository or open issues, etc.), set:

```yaml
permissions:
  contents: read
```

If the workflow later requires more privileges (such as writing pull request comments), this block can be extended. No other code changes, imports, or definitions are required—just insert the `permissions` block in `.github/workflows/pull-request.yml` after the `name` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
