### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/qavajs/steps-memory/security/code-scanning/1](https://github.com/qavajs/steps-memory/security/code-scanning/1)

To fix the referenced problem, add a `permissions` block explicitly either at the workflow root (to apply to all jobs), or at the job (`publish-npm`) level. Since this workflow only has a single job, either approach works; most maintainers put it at the root for future extensibility. As this workflow publishes to npm (which uses secrets for authentication rather than GITHUB_TOKEN), the only GitHub permission needed is for reading and possibly writing repository contents (esp. if tagging or making changes, but in this workflow, only publishing from existing contents). By least privilege, set `permissions: contents: read` at the root. However, if you know for sure that `npm publish` (with this setup) occasionally needs to update repotags, consider `contents: write`. The safest minimal change is to add:

```yaml
permissions:
  contents: read
```

directly under the `name:` key, i.e., at the top of the file before the `on` block.

No new methods or imports are required for this fix—just add the correct configuration lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
