### PR TITLE
Remove NODE_AUTH_TOKEN from npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,5 +22,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN from npm publish step.